### PR TITLE
Remove unnecessary new line 

### DIFF
--- a/src/wifi
+++ b/src/wifi
@@ -100,7 +100,7 @@ then
     		done) 
 
 	printf $GREEN "${list[@]}"
-	echo -e "$ENDCOLOR"
+	echo -ne "$ENDCOLOR"
 	exit 1
 fi
 


### PR DESCRIPTION
## Description

`wifi saved` displays blank line at the tail.
like below.

```
$ src/wifi saved
WiFi-1
WiFi-2

$
```
This PR remove the blank line.