### PR TITLE
fixed issue while connecting to networks with SSID having more than 1 string

### DIFF
--- a/src/wifi
+++ b/src/wifi
@@ -51,7 +51,8 @@ function command_list() {
 
 #Connects to given SSID
 function command_connect() {
-    nmcli dev wifi connect $2
+    shift
+    eval "nmcli dev wifi connect '$@'"
 	exit $?
 }
 


### PR DESCRIPTION
## **Description**
Fixed issue while connecting to networks with SSID having more than 1 string.

## **Related Issue**
https://github.com/TanmayPatil105/wifi-cli/issues/16