### PR TITLE
fixed issue while forgetting networks with SSID having spaces

### DIFF
--- a/src/wifi
+++ b/src/wifi
@@ -148,7 +148,8 @@ function command_hotspot() {
 
 # Forget a wifi network
 function command_forget() {
-	sudo rm /etc/NetworkManager/system-connections/$2.nmconnection
+        shift
+	eval "sudo rm '/etc/NetworkManager/system-connections/$@'"
 	exit $?
 }
 


### PR DESCRIPTION
## **Description**
Fixed issue while forgetting networks with SSID having spaces.

## **Related Issue**
https://github.com/TanmayPatil105/wifi-cli/issues/19