### PR TITLE
Remove eval

### DIFF
--- a/src/wifi
+++ b/src/wifi
@@ -51,9 +51,9 @@ function command_list() {
 
 #Connects to given SSID
 function command_connect() {
-    shift
-    eval "nmcli dev wifi connect '$@'"
-	exit $?
+    nmcli dev wifi connect "$2"
+    # returns same exit code whether comment/uncomment below.
+	# exit $?
 }
 
 # Turns wifi on
@@ -148,9 +148,9 @@ function command_hotspot() {
 
 # Forget a wifi network
 function command_forget() {
-        shift
-	eval "sudo rm '/etc/NetworkManager/system-connections/$@'"
-	exit $?
+	sudo rm "/etc/NetworkManager/system-connections/$2.nmconnection"
+    # returns same exit code whether comment/uncomment below.    
+	# exit $?
 }
 
 if [ $# == 0 ]
@@ -171,4 +171,4 @@ if [[ $(type -t $command) != "function" ]]; then
     exit $?
 fi
 
-eval "$command $(echo "$@")"
+"$command" "$@"


### PR DESCRIPTION
## Description

Remove evals to treat argument contains space correctly.