### PR TITLE
Fix command_forget

### DIFF
--- a/src/wifi
+++ b/src/wifi
@@ -149,8 +149,8 @@ function command_hotspot() {
 # Forget a wifi network
 function command_forget() {
     shift
-	eval "sudo rm '/etc/NetworkManager/system-connections/$@.nmconnection'"
-	exit $?
+    eval "sudo rm '/etc/NetworkManager/system-connections/$@.nmconnection'"
+    exit $?
 }
 
 if [ $# == 0 ]

--- a/src/wifi
+++ b/src/wifi
@@ -148,8 +148,8 @@ function command_hotspot() {
 
 # Forget a wifi network
 function command_forget() {
-        shift
-	eval "sudo rm '/etc/NetworkManager/system-connections/$@'"
+    shift
+	eval "sudo rm '/etc/NetworkManager/system-connections/$@.nmconnection'"
 	exit $?
 }
 


### PR DESCRIPTION
## Description

fix fail to forget SSID. 

## How to reproduce

```
$ src/wifi forget SSID
rm: cannot remove '/etc/NetworkManager/system-connections/SSID': No such file or directory
```