### PR TITLE
Fix #34 installation path and ssid help menu

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-EXE="/bin/wifi"
+EXE="/usr/local/bin/wifi"
 
 if [ $# == 0 ]
 then
 	if [ -f "$EXE" ]
 	then
-		sudo rm /bin/wifi
+		sudo rm /usr/local/bin/wifi
 		echo "Removing $EXE.."
 	fi
 
 	echo "Creating $EXE..."
-	sudo cp ./src/wifi /bin/
+	sudo cp ./src/wifi /usr/local/bin/
 
 	echo "Installed Succesfully"
 fi
@@ -26,7 +26,7 @@ then
 		if [ -f "$EXE" ]
 		then
 			echo "Removing $EXE.."
-			sudo rm /bin/wifi
+			sudo rm /usr/local/bin/wifi
 		fi
 
 		echo "Uninstalled Succesfully!"

--- a/src/wifi
+++ b/src/wifi
@@ -219,12 +219,12 @@ then
 			>		off             turn wifi off
 			>		status          returns wifi status (on/off)
 			>		list            list available wifi networks
-			>		connect $SSID   connect to a wifi network
+			>		connect SSID   connect to a wifi network
 			>		pass            get password of current network
 			>		saved           list all saved networks
 			>		hotspot         to turn on wifi hotspot
 			>		hotspot off     to turn off wifi hotspot
-			>		forget $SSID    to forget a network
+			>		forget SSID    to forget a network
 			>		recon           to reconnect to connected network
 			>		--help, -h      to list all available commands
 


### PR DESCRIPTION
- As mentioned in the issue, I have changed the installation path for the wifi script from **/bin/** to **/usr/local/bin/**. This is done in the installation script - ***install.sh***. Appropriate changes have been made for uninstallation as well in the same script.
-  Earlier wifi --help menu did not show **SSID** as it was supposed to beside the ***connect*** and ***forget*** options. This has also been fixed. 